### PR TITLE
Make mlt_parser compatible with ppxlib.0.18.0

### DIFF
--- a/mlt_parser.opam
+++ b/mlt_parser.opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_expect"  {>= "v0.14" & < "v0.15"}
   "ppx_jane"    {>= "v0.14" & < "v0.15"}
   "dune"        {>= "2.0.0"}
-  "ppxlib"      {>= "0.11.0"}
+  "ppxlib"      {>= "0.18.0"}
 ]
 synopsis: "Parsing of top-expect files"
 description: "

--- a/src/mlt_parser.ml
+++ b/src/mlt_parser.ml
@@ -101,8 +101,8 @@ let declare_org_extension name =
   Extension.Expert.declare name
     Extension.Context.expression
     Ast_pattern.(
-      map (single_expr_payload (pexp_loc __ (pexp_constant (pconst_string __ __))))
-        ~f:(fun f loc s tag -> f (Some (loc, s, tag)))
+      map (single_expr_payload (pexp_loc __ (pexp_constant (pconst_string __ __ __))))
+        ~f:(fun f loc s _loc tag -> f (Some (loc, s, tag)))
       |||
       map (pstr nil)
         ~f:(fun f -> f None)


### PR DESCRIPTION
ppxlib.0.18.0 upgrades to the 4.11 AST which results in a change in string constants representation. This PR makes mlt_parser compatible with the latest ppxlib.

You might want for the actual release of ppxlib.0.18.0 before merging this!